### PR TITLE
Add version checker to ProtectPlugin

### DIFF
--- a/plugin/src/main/java/net/thenextlvl/protect/ProtectPlugin.java
+++ b/plugin/src/main/java/net/thenextlvl/protect/ProtectPlugin.java
@@ -20,6 +20,7 @@ import net.thenextlvl.protect.listener.MovementListener;
 import net.thenextlvl.protect.listener.WorldListener;
 import net.thenextlvl.protect.service.CraftProtectionService;
 import net.thenextlvl.protect.service.ProtectionService;
+import net.thenextlvl.protect.version.PluginVersionChecker;
 import org.bstats.bukkit.Metrics;
 import org.bukkit.Bukkit;
 import org.bukkit.WeatherType;
@@ -37,6 +38,7 @@ import java.util.Locale;
 public class ProtectPlugin extends JavaPlugin {
     private final Metrics metrics = new Metrics(this, 21712);
     private final File schematicFolder = new File(getDataFolder(), "schematics");
+    private final PluginVersionChecker versionChecker = new PluginVersionChecker(this);
 
     private final CraftProtectionService protectionService = new CraftProtectionService(this);
     private final CraftFlagRegistry flagRegistry = new CraftFlagRegistry();
@@ -56,6 +58,8 @@ public class ProtectPlugin extends JavaPlugin {
 
     @Override
     public void onLoad() {
+        versionChecker().checkVersion();
+
         Bukkit.getServicesManager().register(ProtectionService.class, protectionService(), this, ServicePriority.Highest);
         Bukkit.getServicesManager().register(FlagRegistry.class, flagRegistry(), this, ServicePriority.Highest);
         Bukkit.getServicesManager().register(AreaProvider.class, areaProvider(), this, ServicePriority.Highest);

--- a/plugin/src/main/java/net/thenextlvl/protect/version/PluginVersionChecker.java
+++ b/plugin/src/main/java/net/thenextlvl/protect/version/PluginVersionChecker.java
@@ -1,0 +1,17 @@
+package net.thenextlvl.protect.version;
+
+import core.paper.version.PaperHangarVersionChecker;
+import core.version.SemanticVersion;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.Nullable;
+
+public class PluginVersionChecker extends PaperHangarVersionChecker<SemanticVersion> {
+    public PluginVersionChecker(Plugin plugin) {
+        super(plugin, "TheNextLvl", "Protect");
+    }
+
+    @Override
+    public @Nullable SemanticVersion parseVersion(String version) {
+        return SemanticVersion.parse(version);
+    }
+}

--- a/plugin/src/main/java/net/thenextlvl/protect/version/package-info.java
+++ b/plugin/src/main/java/net/thenextlvl/protect/version/package-info.java
@@ -1,0 +1,10 @@
+@TypesAreNotNullByDefault
+@FieldsAreNotNullByDefault
+@MethodsReturnNotNullByDefault
+@ParametersAreNotNullByDefault
+package net.thenextlvl.protect.version;
+
+import core.annotation.FieldsAreNotNullByDefault;
+import core.annotation.MethodsReturnNotNullByDefault;
+import core.annotation.ParametersAreNotNullByDefault;
+import core.annotation.TypesAreNotNullByDefault;


### PR DESCRIPTION
This commit introduces the PluginVersionChecker to ensure the plugin runs on compatible versions. It initializes the version checker and invokes it during the plugin's onLoad method. Additionally, annotations are added to enforce non-null constraints in the new version package.