### PR TITLE
Fix incorrect entity lookup in damage event

### DIFF
--- a/plugin/src/main/java/net/thenextlvl/protect/listener/EntityListener.java
+++ b/plugin/src/main/java/net/thenextlvl/protect/listener/EntityListener.java
@@ -50,7 +50,7 @@ public class EntityListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onEntityDamageByEntity(EntityDamageByEntityEvent event) {
-        var area = plugin.areaProvider().getArea(event.getDamager());
+        var area = plugin.areaProvider().getArea(event.getEntity());
         var flag = event.getDamager() instanceof Player && event.getEntity() instanceof Player
                 ? plugin.flags.playerAttackPlayer : event.getDamager() instanceof Player
                 ? plugin.flags.playerAttackEntity : !(event.getDamager() instanceof Player)


### PR DESCRIPTION
The entity damage event was incorrectly retrieving the damaging entity instead of the damaged entity. This correction ensures that the area lookup is performed on the entity being damaged, which aligns with the intended functionality.