### PR TITLE
Add block fertilize protection flag

### DIFF
--- a/plugin/src/main/java/net/thenextlvl/protect/ProtectPlugin.java
+++ b/plugin/src/main/java/net/thenextlvl/protect/ProtectPlugin.java
@@ -147,6 +147,7 @@ public class ProtectPlugin extends JavaPlugin {
         public final ProtectionFlag<Boolean> blockBurning = flagRegistry().register(ProtectPlugin.this, Boolean.class, "block_burning", true, false);
         public final ProtectionFlag<Boolean> blockDrying = flagRegistry().register(ProtectPlugin.this, Boolean.class, "block_drying", true, false);
         public final ProtectionFlag<Boolean> blockFading = flagRegistry().register(ProtectPlugin.this, Boolean.class, "block_fading", true, false);
+        public final ProtectionFlag<Boolean> blockFertilize = flagRegistry().register(ProtectPlugin.this, Boolean.class, "block_fertilize", true, false);
         public final ProtectionFlag<Boolean> blockGrowth = flagRegistry().register(ProtectPlugin.this, Boolean.class, "block_growth", true, false);
         public final ProtectionFlag<Boolean> blockIgniting = flagRegistry().register(ProtectPlugin.this, Boolean.class, "block_igniting", true, false);
         public final ProtectionFlag<Boolean> blockMoisturising = flagRegistry().register(ProtectPlugin.this, Boolean.class, "block_moisturising", true, false);

--- a/plugin/src/main/java/net/thenextlvl/protect/listener/WorldListener.java
+++ b/plugin/src/main/java/net/thenextlvl/protect/listener/WorldListener.java
@@ -129,6 +129,14 @@ public class WorldListener implements Listener {
     }
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+    public void onBlockFertilize(BlockFertilizeEvent event) {
+        event.getBlocks().removeIf(block -> {
+            var area = plugin.areaProvider().getArea(block.getBlock());
+            return !area.getFlag(plugin.flags.blockFertilize);
+        });
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onBlockExplode(BlockExplodeEvent event) {
         event.blockList().removeIf(block -> {
             var area = plugin.areaProvider().getArea(block);


### PR DESCRIPTION
Introduced a new protection flag to control block fertilization. Implemented an event handler to respect this flag during BlockFertilizeEvent, ensuring proper area protection.