### PR TITLE
Add interaction capability check for areas

### DIFF
--- a/api/src/main/java/net/thenextlvl/protect/area/Area.java
+++ b/api/src/main/java/net/thenextlvl/protect/area/Area.java
@@ -43,6 +43,14 @@ public interface Area extends Container, FlagProvider, Comparable<Area> {
     boolean setPriority(int priority);
 
     /**
+     * Determines whether this area can interact with another area.
+     *
+     * @param area the area to check interaction capability with
+     * @return true if this area can interact with the specified area, false otherwise
+     */
+    boolean canInteract(Area area);
+
+    /**
      * Retrieves the world associated with this Area.
      *
      * @return the world associated with this Area

--- a/plugin/src/main/java/net/thenextlvl/protect/area/CraftGlobalArea.java
+++ b/plugin/src/main/java/net/thenextlvl/protect/area/CraftGlobalArea.java
@@ -34,6 +34,11 @@ public class CraftGlobalArea extends CraftArea implements GlobalArea {
     }
 
     @Override
+    public boolean canInteract(Area area) {
+        return false;
+    }
+
+    @Override
     public List<Entity> getEntities() {
         return getWorld().getEntities();
     }

--- a/plugin/src/main/java/net/thenextlvl/protect/area/CraftRegionizedArea.java
+++ b/plugin/src/main/java/net/thenextlvl/protect/area/CraftRegionizedArea.java
@@ -18,12 +18,12 @@ import core.annotation.TypesAreNotNullByDefault;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
+import net.thenextlvl.protect.area.event.member.AreaMemberAddEvent;
+import net.thenextlvl.protect.area.event.member.AreaMemberRemoveEvent;
 import net.thenextlvl.protect.area.event.member.AreaOwnerChangeEvent;
 import net.thenextlvl.protect.area.event.region.AreaRedefineEvent;
 import net.thenextlvl.protect.area.event.schematic.AreaSchematicDeleteEvent;
 import net.thenextlvl.protect.area.event.schematic.AreaSchematicLoadEvent;
-import net.thenextlvl.protect.area.event.member.AreaMemberAddEvent;
-import net.thenextlvl.protect.area.event.member.AreaMemberRemoveEvent;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Entity;
@@ -113,6 +113,11 @@ public abstract class CraftRegionizedArea<T extends Region> extends CraftArea im
         var event = new AreaOwnerChangeEvent<>(this, owner);
         if (event.callEvent()) this.owner = event.getOwner();
         return !event.isCancelled();
+    }
+
+    @Override
+    public boolean canInteract(Area area) {
+        return area instanceof RegionizedArea<?> regionized && Objects.equals(regionized.getOwner(), getOwner());
     }
 
     @Override


### PR DESCRIPTION
Introduced a new `canInteract` method in the `Area` interface to determine whether an area can interact with another area. Implemented this method in `CraftGlobalArea` and `CraftRegionizedArea` with specific logic for interaction.