### PR TITLE
Added area enter/leave titles and actionbars

### DIFF
--- a/plugin/src/main/java/net/thenextlvl/protect/ProtectPlugin.java
+++ b/plugin/src/main/java/net/thenextlvl/protect/ProtectPlugin.java
@@ -145,7 +145,11 @@ public class ProtectPlugin extends JavaPlugin {
         public final Flag<@Nullable Location> teleportLocation = flagRegistry().register(ProtectPlugin.this, Location.class, "teleport_location", null);
         public final Flag<@Nullable Long> time = flagRegistry().register(ProtectPlugin.this, Long.class, "time", null);
         public final Flag<@Nullable String> farewell = flagRegistry().register(ProtectPlugin.this, String.class, "farewell", null);
+        public final Flag<@Nullable String> farewellActionbar = flagRegistry().register(ProtectPlugin.this, String.class, "farewell_actionbar", null);
+        public final Flag<@Nullable String> farewellTitle = flagRegistry().register(ProtectPlugin.this, String.class, "farewell_title", null);
         public final Flag<@Nullable String> greetings = flagRegistry().register(ProtectPlugin.this, String.class, "greetings", null);
+        public final Flag<@Nullable String> greetingsActionbar = flagRegistry().register(ProtectPlugin.this, String.class, "greetings_actionbar", null);
+        public final Flag<@Nullable String> greetingsTitle = flagRegistry().register(ProtectPlugin.this, String.class, "greetings_title", null);
         public final Flag<@Nullable WeatherType> weather = flagRegistry().register(ProtectPlugin.this, WeatherType.class, "weather", null);
 
         public final Flag<Boolean> areaEnter = flagRegistry().register(ProtectPlugin.this, "enter", true);

--- a/plugin/src/main/java/net/thenextlvl/protect/command/AreaFlagCommand.java
+++ b/plugin/src/main/java/net/thenextlvl/protect/command/AreaFlagCommand.java
@@ -164,7 +164,7 @@ class AreaFlagCommand {
         plugin.bundle().sendMessage(context.getSource().getSender(), message,
                 Placeholder.parsed("area", area.getName()),
                 Placeholder.parsed("flag", flag.key().asString()),
-                Placeholder.parsed("value", String.valueOf(value)));
+                Placeholder.unparsed("value", String.valueOf(value)));
         return Command.SINGLE_SUCCESS;
     }
 


### PR DESCRIPTION
# Added new flags
- `protect:farewell_actionbar` - _shows an actionbar to the player when leaving an area_
- `protect:farewell_title` - _shows a title to the player when leaving an area_
- `protect:greetings_actionbar` - _shows an actionbar to the player when entering an area_
- `protect:greetings_title` - _shows a title to the player when entering an area_

## In all farewell and greetings messages the following placeholders are now resolved
- `<area>` - _the corresponding area's name_
- `<player>` - _the player's name_