### PR TITLE
Refactor to replace NamespacedKey with Key from Adventure API

### DIFF
--- a/api/src/main/java/net/thenextlvl/protect/area/AreaService.java
+++ b/api/src/main/java/net/thenextlvl/protect/area/AreaService.java
@@ -1,8 +1,8 @@
 package net.thenextlvl.protect.area;
 
 import com.sk89q.worldedit.regions.Region;
+import net.kyori.adventure.key.Key;
 import net.thenextlvl.protect.io.AreaAdapter;
-import org.bukkit.NamespacedKey;
 import org.bukkit.World;
 import org.jspecify.annotations.NullMarked;
 
@@ -120,10 +120,10 @@ public interface AreaService {
     /**
      * Retrieves the adapter for serializing and deserializing objects of type T that implement the Area interface.
      *
-     * @param key The NamespacedKey representing the type of the area object.
+     * @param key The Key representing the type of the area object.
      * @param <T> The type of the area object.
      * @return The adapter for the specified area type.
      * @throws IllegalArgumentException thrown if no adapter for the specified key was registered.
      */
-    <T extends Area> AreaAdapter<T> getAdapter(NamespacedKey key) throws IllegalArgumentException;
+    <T extends Area> AreaAdapter<T> getAdapter(Key key) throws IllegalArgumentException;
 }

--- a/api/src/main/java/net/thenextlvl/protect/flag/Flag.java
+++ b/api/src/main/java/net/thenextlvl/protect/flag/Flag.java
@@ -1,6 +1,6 @@
 package net.thenextlvl.protect.flag;
 
-import org.bukkit.NamespacedKey;
+import net.kyori.adventure.key.Key;
 import org.jspecify.annotations.NonNull;
 
 /**
@@ -10,12 +10,12 @@ import org.jspecify.annotations.NonNull;
  */
 public interface Flag<T> extends Comparable<@NonNull Flag<?>> {
     /**
-     * Retrieves the {@link NamespacedKey} associated with this flag.
+     * Retrieves the {@link Key} associated with this flag.
      *
-     * @return the NamespacedKey of the flag
+     * @return the Key of the flag
      */
     @NonNull
-    NamespacedKey key();
+    Key key();
 
     /**
      * Retrieves the type of the flag value.

--- a/api/src/main/java/net/thenextlvl/protect/flag/FlagRegistry.java
+++ b/api/src/main/java/net/thenextlvl/protect/flag/FlagRegistry.java
@@ -1,7 +1,7 @@
 package net.thenextlvl.protect.flag;
 
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.key.KeyPattern;
-import org.bukkit.NamespacedKey;
 import org.bukkit.plugin.Plugin;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullMarked;
@@ -32,14 +32,14 @@ public interface FlagRegistry {
     Set<Flag<?>> getFlags(Plugin plugin);
 
     /**
-     * Retrieves the flag associated with the given NamespacedKey.
+     * Retrieves the flag associated with the given Key.
      *
-     * @param key the NamespacedKey of the flag to retrieve
+     * @param key the Key of the flag to retrieve
      * @param <T> the type of the flag value
      * @return an Optional containing the flag, or an empty Optional if no flag was found
      */
     @NullMarked
-    <T> Optional<Flag<T>> getFlag(NamespacedKey key);
+    <T> Optional<Flag<T>> getFlag(Key key);
 
     /**
      * Registers a new flag with the specified plugin, name, and default value.
@@ -113,12 +113,12 @@ public interface FlagRegistry {
     ) throws IllegalStateException;
 
     /**
-     * Unregisters a flag identified by the given NamespacedKey.
+     * Unregisters a flag identified by the given Key.
      *
-     * @param flag the NamespacedKey of the flag to unregister
+     * @param flag the Key of the flag to unregister
      * @return true if the flag was unregistered, false otherwise
      */
-    boolean unregister(@NonNull NamespacedKey flag);
+    boolean unregister(@NonNull Key flag);
 
     /**
      * Unregisters all flags associated with the specified plugin.

--- a/api/src/main/java/net/thenextlvl/protect/io/AreaAdapter.java
+++ b/api/src/main/java/net/thenextlvl/protect/io/AreaAdapter.java
@@ -1,9 +1,9 @@
 package net.thenextlvl.protect.io;
 
 import core.nbt.tag.CompoundTag;
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.key.Keyed;
 import net.thenextlvl.protect.area.Area;
-import org.bukkit.NamespacedKey;
 import org.bukkit.World;
 import org.jspecify.annotations.NullMarked;
 
@@ -20,14 +20,14 @@ public interface AreaAdapter<T extends Area> extends Keyed {
      *
      * @return The key associated with the adapter.
      */
-    NamespacedKey key();
+    Key key();
 
     /**
      * Constructs an Area object using the provided world, name, and CompoundTag.
      *
      * @param world the World associated with the Area
-     * @param name the name of the Area
-     * @param tag the CompoundTag containing the serialized data of the Area
+     * @param name  the name of the Area
+     * @param tag   the CompoundTag containing the serialized data of the Area
      * @return the constructed Area object
      */
     Area construct(World world, String name, CompoundTag tag);

--- a/plugin/src/main/java/net/thenextlvl/protect/ProtectPlugin.java
+++ b/plugin/src/main/java/net/thenextlvl/protect/ProtectPlugin.java
@@ -16,6 +16,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.experimental.Accessors;
 import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
@@ -47,7 +48,6 @@ import net.thenextlvl.protect.service.ProtectionService;
 import net.thenextlvl.protect.version.PluginVersionChecker;
 import org.bstats.bukkit.Metrics;
 import org.bukkit.Location;
-import org.bukkit.NamespacedKey;
 import org.bukkit.WeatherType;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
@@ -167,7 +167,7 @@ public class ProtectPlugin extends JavaPlugin {
             .registerTypeAdapter(new TypeToken<Set<UUID>>() {
             }.getType(), new MembersAdapter())
             .registerTypeHierarchyAdapter(Location.class, new LocationAdapter())
-            .registerTypeHierarchyAdapter(NamespacedKey.class, new NamespaceAdapter())
+            .registerTypeHierarchyAdapter(Key.class, new KeyAdapter())
             .registerTypeHierarchyAdapter(WeatherType.class, new WeatherTypeAdapter())
             .registerTypeHierarchyAdapter(World.class, new WorldAdapter(getServer()))
             .registerTypeHierarchyAdapter(CuboidRegion.class, new CuboidRegionAdapter())

--- a/plugin/src/main/java/net/thenextlvl/protect/adapter/area/GlobalAreaAdapter.java
+++ b/plugin/src/main/java/net/thenextlvl/protect/adapter/area/GlobalAreaAdapter.java
@@ -3,22 +3,22 @@ package net.thenextlvl.protect.adapter.area;
 import core.nbt.tag.CompoundTag;
 import lombok.Getter;
 import lombok.experimental.Accessors;
+import net.kyori.adventure.key.Key;
 import net.thenextlvl.protect.ProtectPlugin;
 import net.thenextlvl.protect.area.Area;
 import net.thenextlvl.protect.area.CraftGlobalArea;
 import net.thenextlvl.protect.io.AreaAdapter;
-import org.bukkit.NamespacedKey;
 import org.bukkit.World;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
 @Accessors(fluent = true)
 public class GlobalAreaAdapter implements AreaAdapter<CraftGlobalArea> {
-    private final @Getter NamespacedKey key;
+    private final @Getter Key key;
     private final ProtectPlugin plugin;
 
     public GlobalAreaAdapter(ProtectPlugin plugin) {
-        this.key = new NamespacedKey(plugin, "global");
+        this.key = Key.key("protect:global");
         this.plugin = plugin;
     }
 

--- a/plugin/src/main/java/net/thenextlvl/protect/adapter/area/RegionizedAreaAdapter.java
+++ b/plugin/src/main/java/net/thenextlvl/protect/adapter/area/RegionizedAreaAdapter.java
@@ -3,21 +3,21 @@ package net.thenextlvl.protect.adapter.area;
 import com.sk89q.worldedit.regions.Region;
 import lombok.Getter;
 import lombok.experimental.Accessors;
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.key.KeyPattern;
 import net.thenextlvl.protect.ProtectPlugin;
 import net.thenextlvl.protect.area.CraftRegionizedArea;
 import net.thenextlvl.protect.io.AreaAdapter;
-import org.bukkit.NamespacedKey;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
 @Accessors(fluent = true)
 public abstract class RegionizedAreaAdapter<C extends Region, T extends CraftRegionizedArea<C>> implements AreaAdapter<T> {
-    private final @Getter NamespacedKey key;
+    private final @Getter Key key;
     protected final ProtectPlugin plugin;
 
     public RegionizedAreaAdapter(ProtectPlugin plugin, @KeyPattern.Value String name) {
-        this.key = new NamespacedKey(plugin, name);
+        this.key = Key.key("protect", name);
         this.plugin = plugin;
     }
 }

--- a/plugin/src/main/java/net/thenextlvl/protect/adapter/other/FlagsAdapter.java
+++ b/plugin/src/main/java/net/thenextlvl/protect/adapter/other/FlagsAdapter.java
@@ -6,9 +6,9 @@ import core.nbt.serialization.TagSerializationContext;
 import core.nbt.tag.CompoundTag;
 import core.nbt.tag.Tag;
 import lombok.RequiredArgsConstructor;
+import net.kyori.adventure.key.Key;
 import net.thenextlvl.protect.ProtectPlugin;
 import net.thenextlvl.protect.flag.Flag;
-import org.bukkit.NamespacedKey;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -21,12 +21,13 @@ public class FlagsAdapter implements TagAdapter<Map<Flag<?>, @Nullable Object>> 
     private final ProtectPlugin plugin;
 
     @Override
+    @SuppressWarnings("PatternValidation")
     public Map<Flag<?>, @Nullable Object> deserialize(Tag tag, TagDeserializationContext context) {
         var compound = tag.getAsCompound();
         var flags = new HashMap<Flag<?>, @Nullable Object>();
         compound.forEach((key, value) -> {
-            var namespace = NamespacedKey.fromString(key);
-            var flag = namespace != null ? plugin.flagRegistry().getFlag(namespace).orElse(null) : null;
+            var namespace = Key.key(key);
+            var flag = plugin.flagRegistry().getFlag(namespace).orElse(null);
             if (flag != null) flags.put(flag, context.deserialize(value, flag.type()));
             else plugin.getComponentLogger().error("Unknown flag: {}", key);
         });

--- a/plugin/src/main/java/net/thenextlvl/protect/adapter/other/KeyAdapter.java
+++ b/plugin/src/main/java/net/thenextlvl/protect/adapter/other/KeyAdapter.java
@@ -6,19 +6,20 @@ import core.nbt.serialization.TagDeserializationContext;
 import core.nbt.serialization.TagSerializationContext;
 import core.nbt.tag.StringTag;
 import core.nbt.tag.Tag;
-import org.bukkit.NamespacedKey;
+import net.kyori.adventure.key.Key;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-public class NamespaceAdapter implements TagAdapter<NamespacedKey> {
+public class KeyAdapter implements TagAdapter<Key> {
     @Override
-    public NamespacedKey deserialize(Tag tag, TagDeserializationContext context) throws ParserException {
+    @SuppressWarnings("PatternValidation")
+    public Key deserialize(Tag tag, TagDeserializationContext context) throws ParserException {
         var split = tag.getAsString().split(":", 2);
-        return new NamespacedKey(split[0], split[1]);
+        return Key.key(split[0], split[1]);
     }
 
     @Override
-    public Tag serialize(NamespacedKey key, TagSerializationContext context) throws ParserException {
+    public Tag serialize(Key key, TagSerializationContext context) throws ParserException {
         return new StringTag(key.toString());
     }
 }

--- a/plugin/src/main/java/net/thenextlvl/protect/adapter/other/WorldAdapter.java
+++ b/plugin/src/main/java/net/thenextlvl/protect/adapter/other/WorldAdapter.java
@@ -5,7 +5,7 @@ import core.nbt.serialization.TagAdapter;
 import core.nbt.serialization.TagDeserializationContext;
 import core.nbt.serialization.TagSerializationContext;
 import core.nbt.tag.Tag;
-import org.bukkit.NamespacedKey;
+import net.kyori.adventure.key.Key;
 import org.bukkit.Server;
 import org.bukkit.World;
 import org.jspecify.annotations.NullMarked;
@@ -20,7 +20,7 @@ public class WorldAdapter implements TagAdapter<World> {
 
     @Override
     public World deserialize(Tag tag, TagDeserializationContext context) throws ParserException {
-        var namespace = context.deserialize(tag, NamespacedKey.class);
+        var namespace = context.deserialize(tag, Key.class);
         var world = server.getWorld(namespace);
         if (world != null) return world;
         throw new ParserException("World not found: " + namespace);

--- a/plugin/src/main/java/net/thenextlvl/protect/area/CraftAreaProvider.java
+++ b/plugin/src/main/java/net/thenextlvl/protect/area/CraftAreaProvider.java
@@ -5,10 +5,10 @@ import core.nbt.NBTInputStream;
 import core.nbt.NBTOutputStream;
 import core.nbt.serialization.ParserException;
 import lombok.RequiredArgsConstructor;
+import net.kyori.adventure.key.Key;
 import net.thenextlvl.protect.ProtectPlugin;
 import net.thenextlvl.protect.area.event.AreaLoadEvent;
 import org.bukkit.Location;
-import org.bukkit.NamespacedKey;
 import org.bukkit.World;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -110,7 +110,7 @@ public class CraftAreaProvider implements AreaProvider {
             var entry = inputStream.readNamedTag();
             var root = entry.getKey().getAsCompound();
             var name = entry.getValue().orElseThrow(() -> new ParserException("Area misses root name"));
-            var type = plugin.nbt.fromTag(root.get("type"), NamespacedKey.class);
+            var type = plugin.nbt.fromTag(root.get("type"), Key.class);
             return plugin.areaService().getAdapter(type).construct(world, name, root);
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/plugin/src/main/java/net/thenextlvl/protect/area/CraftAreaService.java
+++ b/plugin/src/main/java/net/thenextlvl/protect/area/CraftAreaService.java
@@ -3,12 +3,12 @@ package net.thenextlvl.protect.area;
 import com.google.common.base.Preconditions;
 import com.sk89q.worldedit.regions.Region;
 import lombok.RequiredArgsConstructor;
+import net.kyori.adventure.key.Key;
 import net.thenextlvl.protect.ProtectPlugin;
 import net.thenextlvl.protect.area.event.AreaDeleteEvent;
 import net.thenextlvl.protect.area.event.player.PlayerAreaLeaveEvent;
 import net.thenextlvl.protect.area.event.player.PlayerAreaTransitionEvent;
 import net.thenextlvl.protect.io.AreaAdapter;
-import org.bukkit.NamespacedKey;
 import org.bukkit.World;
 import org.jspecify.annotations.NullMarked;
 
@@ -97,7 +97,7 @@ public class CraftAreaService implements AreaService {
 
     @Override
     @SuppressWarnings("unchecked")
-    public <T extends Area> AreaAdapter<T> getAdapter(NamespacedKey key) throws IllegalArgumentException {
+    public <T extends Area> AreaAdapter<T> getAdapter(Key key) throws IllegalArgumentException {
         return (AreaAdapter<T>) adapters.values().stream()
                 .filter(adapter -> adapter.key().equals(key))
                 .findAny().orElseThrow(() -> new IllegalArgumentException("No adapter for key: " + key));

--- a/plugin/src/main/java/net/thenextlvl/protect/command/argument/FlagArgumentType.java
+++ b/plugin/src/main/java/net/thenextlvl/protect/command/argument/FlagArgumentType.java
@@ -2,26 +2,26 @@ package net.thenextlvl.protect.command.argument;
 
 import core.paper.command.WrappedArgumentType;
 import io.papermc.paper.command.brigadier.argument.ArgumentTypes;
+import net.kyori.adventure.key.Key;
 import net.thenextlvl.protect.ProtectPlugin;
 import net.thenextlvl.protect.flag.Flag;
-import org.bukkit.NamespacedKey;
 
 import java.util.function.Predicate;
 
 @SuppressWarnings("UnstableApiUsage")
-public class FlagArgumentType extends WrappedArgumentType<NamespacedKey, Flag<?>> {
+public class FlagArgumentType extends WrappedArgumentType<Key, Flag<?>> {
     public FlagArgumentType(ProtectPlugin plugin) {
         this(plugin, flag -> true);
     }
 
     public FlagArgumentType(ProtectPlugin plugin, Predicate<? super Flag<?>> filter) {
-        super(ArgumentTypes.namespacedKey(), (reader, type) -> plugin.flagRegistry().getFlag(type)
+        super(ArgumentTypes.key(), (reader, type) -> plugin.flagRegistry().getFlag(type)
                         .filter(filter).orElseThrow(() -> new IllegalArgumentException("Unknown flag: " + type)),
                 (context, builder) -> {
                     plugin.flagRegistry().getFlags().stream()
                             .filter(filter)
                             .map(Flag::key)
-                            .map(NamespacedKey::asString)
+                            .map(Key::asString)
                             .filter(s -> s.contains(builder.getRemaining()))
                             .forEach(builder::suggest);
                     return builder.buildFuture();

--- a/plugin/src/main/java/net/thenextlvl/protect/flag/CraftFlag.java
+++ b/plugin/src/main/java/net/thenextlvl/protect/flag/CraftFlag.java
@@ -1,12 +1,12 @@
 package net.thenextlvl.protect.flag;
 
-import org.bukkit.NamespacedKey;
+import net.kyori.adventure.key.Key;
 import org.jspecify.annotations.NonNull;
 
 import java.util.Objects;
 
 public record CraftFlag<T>(
-        @NonNull NamespacedKey key,
+        @NonNull Key key,
         @NonNull Class<? extends T> type,
         T defaultValue
 ) implements Flag<T> {

--- a/plugin/src/main/java/net/thenextlvl/protect/flag/CraftFlagRegistry.java
+++ b/plugin/src/main/java/net/thenextlvl/protect/flag/CraftFlagRegistry.java
@@ -1,8 +1,8 @@
 package net.thenextlvl.protect.flag;
 
 import lombok.Getter;
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.key.KeyPattern;
-import org.bukkit.NamespacedKey;
 import org.bukkit.plugin.Plugin;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullMarked;
@@ -32,7 +32,7 @@ public class CraftFlagRegistry implements FlagRegistry {
     @Override
     @NullMarked
     @SuppressWarnings("unchecked")
-    public <T> Optional<Flag<T>> getFlag(NamespacedKey key) {
+    public <T> Optional<Flag<T>> getFlag(Key key) {
         return getFlags().stream()
                 .filter(flag -> flag.key().equals(key))
                 .map(flag -> (Flag<T>) flag)
@@ -49,15 +49,16 @@ public class CraftFlagRegistry implements FlagRegistry {
         return register(plugin, name, key -> new CraftProtectionFlag<>(key, type, defaultValue, protectedValue));
     }
 
-    private <T extends Flag<?>> T register(@NonNull Plugin plugin, @KeyPattern.Value @NonNull String name, @NonNull Function<NamespacedKey, T> function) {
-        var key = new NamespacedKey(plugin, name);
+    @SuppressWarnings("PatternValidation")
+    private <T extends Flag<?>> T register(@NonNull Plugin plugin, @KeyPattern.Value @NonNull String name, @NonNull Function<Key, T> function) {
+        var key = Key.key(plugin.getName().replace("-", "_").toLowerCase(), name);
         var flag = function.apply(key);
         if (registry.computeIfAbsent(plugin, p -> new HashSet<>()).add(flag)) return flag;
         throw new IllegalStateException("Already registered flag: " + key);
     }
 
     @Override
-    public boolean unregister(@NonNull NamespacedKey key) {
+    public boolean unregister(@NonNull Key key) {
         for (var flags : registry.values()) if (flags.removeIf(flag -> flag.key().equals(key))) return true;
         return false;
     }

--- a/plugin/src/main/java/net/thenextlvl/protect/flag/CraftProtectionFlag.java
+++ b/plugin/src/main/java/net/thenextlvl/protect/flag/CraftProtectionFlag.java
@@ -1,12 +1,12 @@
 package net.thenextlvl.protect.flag;
 
-import org.bukkit.NamespacedKey;
+import net.kyori.adventure.key.Key;
 import org.jspecify.annotations.NonNull;
 
 import java.util.Objects;
 
 public record CraftProtectionFlag<T>(
-        @NonNull NamespacedKey key,
+        @NonNull Key key,
         @NonNull Class<? extends T> type,
         T defaultValue, T protectedValue
 ) implements ProtectionFlag<T> {


### PR DESCRIPTION
Updated all instances of NamespacedKey to Key from Kyori Adventure API for consistency and modernization. This involved changing method signatures, variable declarations, imports, and classes to ensure proper integration of the Key type.