### PR TITLE
Update nbt dependency versions

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
         exclude("org.jetbrains", "annotations")
     }
 
-    implementation("net.thenextlvl.core:nbt:2.2.13")
+    implementation("net.thenextlvl.core:nbt:2.2.14")
     implementation("net.thenextlvl.core:files:2.0.0")
     implementation(platform("com.intellectualsites.bom:bom-newest:1.50"))
 

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -42,7 +42,7 @@ dependencies {
     implementation(project(":api"))
     implementation("net.thenextlvl.core:files:2.0.0")
     implementation("net.thenextlvl.core:i18n:1.0.20")
-    implementation("net.thenextlvl.core:nbt:2.2.13")
+    implementation("net.thenextlvl.core:nbt:2.2.14")
     implementation("net.thenextlvl.core:paper:1.5.3")
 
     annotationProcessor("org.projectlombok:lombok:1.18.34")


### PR DESCRIPTION
Upgraded the net.thenextlvl.core:nbt dependency from version 2.2.13 to 2.2.14 in both the plugin and api modules. This ensures compatibility and may include bug fixes or improvements from the newer library version.