### PR TITLE
Simplify area teleportation logic

### DIFF
--- a/api/src/main/java/net/thenextlvl/protect/area/RegionizedArea.java
+++ b/api/src/main/java/net/thenextlvl/protect/area/RegionizedArea.java
@@ -4,6 +4,7 @@ import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.regions.RegionSelector;
 import net.thenextlvl.protect.exception.CircularInheritanceException;
 import net.thenextlvl.protect.schematic.SchematicHolder;
+import org.bukkit.Location;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -15,6 +16,13 @@ import org.jspecify.annotations.Nullable;
  */
 @NullMarked
 public interface RegionizedArea<T extends Region> extends Area, SchematicHolder {
+    /**
+     * Retrieves the location of this area.
+     *
+     * @return the location of this area.
+     */
+    Location getLocation();
+
     /**
      * Retrieves the RegionSelector associated with this RegionizedArea.
      *

--- a/plugin/src/main/java/net/thenextlvl/protect/command/AreaTeleportCommand.java
+++ b/plugin/src/main/java/net/thenextlvl/protect/command/AreaTeleportCommand.java
@@ -10,7 +10,6 @@ import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.thenextlvl.protect.ProtectPlugin;
 import net.thenextlvl.protect.area.RegionizedArea;
 import net.thenextlvl.protect.command.argument.RegionizedAreaArgumentType;
-import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerTeleportEvent;
 
@@ -30,13 +29,7 @@ class AreaTeleportCommand {
     private int teleport(CommandContext<CommandSourceStack> context) {
         var player = (Player) context.getSource().getSender();
         var area = context.getArgument("area", RegionizedArea.class);
-        var point = area.getRegion().getMaximumPoint();
-        var location = new Location(area.getWorld(), point.x() + 0.5, point.y(), point.z() + 0.5);
-        var block = location.getWorld().getHighestBlockAt(location);
-        if (block.getY() < location.getY()) location.setY(block.getY() + 1);
-        location.setPitch(player.getLocation().getPitch());
-        location.setYaw(player.getLocation().getYaw());
-        player.teleportAsync(location, PlayerTeleportEvent.TeleportCause.COMMAND).thenAccept(success -> {
+        player.teleportAsync(area.getLocation(), PlayerTeleportEvent.TeleportCause.COMMAND).thenAccept(success -> {
             var message = success ? "area.teleport.success" : "area.teleport.fail";
             plugin.bundle().sendMessage(player, message, Placeholder.parsed("area", area.getName()));
         });


### PR DESCRIPTION
Streamlined the area teleportation process by introducing a new `getLocation` method in the `RegionizedArea` interface and its implementation in `CraftRegionizedArea`. This refactor eliminates manual location calculations in the `AreaTeleportCommand`, improving maintainability and readability.