### PR TITLE
Add liquid flow restriction flag

### DIFF
--- a/plugin/src/main/java/net/thenextlvl/protect/ProtectPlugin.java
+++ b/plugin/src/main/java/net/thenextlvl/protect/ProtectPlugin.java
@@ -228,6 +228,7 @@ public class ProtectPlugin extends JavaPlugin {
         public final Flag<Boolean> hunger = flagRegistry().register(ProtectPlugin.this, Boolean.class, "hunger", true);
         public final Flag<Boolean> interact = flagRegistry().register(ProtectPlugin.this, Boolean.class, "interact", true, false);
         public final Flag<Boolean> leavesDecay = flagRegistry().register(ProtectPlugin.this, Boolean.class, "leaves_decay", true, false);
+        public final Flag<Boolean> liquidFlow = flagRegistry().register(ProtectPlugin.this, Boolean.class, "liquid_flow", true, false);
         public final Flag<Boolean> naturalCauldronFill = flagRegistry().register(ProtectPlugin.this, Boolean.class, "natural_cauldron_fill", true, false);
         public final Flag<Boolean> naturalEntitySpawn = flagRegistry().register(ProtectPlugin.this, Boolean.class, "natural_entity_spawn", true);
         public final Flag<Boolean> physicalInteract = flagRegistry().register(ProtectPlugin.this, Boolean.class, "physical_interact", true, false);

--- a/plugin/src/main/java/net/thenextlvl/protect/listener/WorldListener.java
+++ b/plugin/src/main/java/net/thenextlvl/protect/listener/WorldListener.java
@@ -151,11 +151,12 @@ public class WorldListener implements Listener {
     }
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
-    public void onBlockFromTo(BlockFromToEvent event) {
+    public void onLiquidFlow(BlockFromToEvent event) {
+        if (!event.getBlock().isLiquid()) return;
         event.setCancelled(isInteractionRestricted(
                 event.getBlock().getLocation(),
                 event.getToBlock().getLocation(),
-                plugin.flags.physics
+                plugin.flags.liquidFlow
         ));
     }
 


### PR DESCRIPTION
Implemented a new `liquidFlow` flag to control liquid movement in the plugin. Updated `WorldListener` to check this flag during `BlockFromToEvent` to prevent undesired liquid flow interactions.