### PR TITLE
Refactor physics handling into a new listener

### DIFF
--- a/plugin/src/main/java/net/thenextlvl/protect/ProtectPlugin.java
+++ b/plugin/src/main/java/net/thenextlvl/protect/ProtectPlugin.java
@@ -36,10 +36,7 @@ import net.thenextlvl.protect.command.AreaCommand;
 import net.thenextlvl.protect.flag.CraftFlagRegistry;
 import net.thenextlvl.protect.flag.Flag;
 import net.thenextlvl.protect.flag.FlagRegistry;
-import net.thenextlvl.protect.listener.AreaListener;
-import net.thenextlvl.protect.listener.EntityListener;
-import net.thenextlvl.protect.listener.MovementListener;
-import net.thenextlvl.protect.listener.WorldListener;
+import net.thenextlvl.protect.listener.*;
 import net.thenextlvl.protect.mask.ProtectMaskManager;
 import net.thenextlvl.protect.region.GroupedRegion;
 import net.thenextlvl.protect.service.CraftProtectionService;
@@ -138,6 +135,7 @@ public class ProtectPlugin extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new AreaListener(this), this);
         getServer().getPluginManager().registerEvents(new EntityListener(this), this);
         getServer().getPluginManager().registerEvents(new MovementListener(this), this);
+        getServer().getPluginManager().registerEvents(new PhysicsListener(this), this);
         getServer().getPluginManager().registerEvents(new WorldListener(this), this);
     }
 
@@ -224,6 +222,7 @@ public class ProtectPlugin extends JavaPlugin {
         public final Flag<Boolean> fillBottle = flagRegistry().register(ProtectPlugin.this, Boolean.class, "fill_bottle", true, false);
         public final Flag<Boolean> fillBucket = flagRegistry().register(ProtectPlugin.this, Boolean.class, "fill_bucket", true, false);
         public final Flag<Boolean> gameEvents = flagRegistry().register(ProtectPlugin.this, Boolean.class, "game_events", true);
+        public final Flag<Boolean> gravity = flagRegistry().register(ProtectPlugin.this, Boolean.class, "gravity", true);
         public final Flag<Boolean> hunger = flagRegistry().register(ProtectPlugin.this, Boolean.class, "hunger", true);
         public final Flag<Boolean> interact = flagRegistry().register(ProtectPlugin.this, Boolean.class, "interact", true, false);
         public final Flag<Boolean> leavesDecay = flagRegistry().register(ProtectPlugin.this, Boolean.class, "leaves_decay", true, false);

--- a/plugin/src/main/java/net/thenextlvl/protect/listener/PhysicsListener.java
+++ b/plugin/src/main/java/net/thenextlvl/protect/listener/PhysicsListener.java
@@ -1,0 +1,54 @@
+package net.thenextlvl.protect.listener;
+
+import lombok.RequiredArgsConstructor;
+import net.thenextlvl.protect.ProtectPlugin;
+import net.thenextlvl.protect.flag.Flag;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.Powerable;
+import org.bukkit.block.data.type.*;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockPhysicsEvent;
+import org.jspecify.annotations.Nullable;
+
+@RequiredArgsConstructor
+public class PhysicsListener implements Listener {
+    private final ProtectPlugin plugin;
+
+    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+    public void onPhysics(BlockPhysicsEvent event) {
+
+        if ((event.getSourceBlock().isEmpty() && event.getChangedType().isEmpty()) || (
+                event.getSourceBlock().getType().equals(Material.SNOW)
+                || event.getSourceBlock().getType().equals(Material.POWDER_SNOW)
+                || event.getSourceBlock().getType().equals(Material.SNOW_BLOCK))) {
+            if (event.getBlock().getRelative(BlockFace.DOWN).getType().equals(Material.GRASS_BLOCK)) {
+                return;
+            }
+        }
+
+        if (event.getChangedType().equals(Material.IRON_BARS)
+            || event.getChangedBlockData() instanceof Stairs
+            || event.getChangedBlockData() instanceof Chest
+            || event.getChangedBlockData() instanceof Fence
+            || event.getChangedBlockData() instanceof GlassPane
+            || event.getChangedBlockData() instanceof Wall
+            || event.getChangedBlockData() instanceof Door) {
+            return;
+        }
+
+        if (event.getChangedBlockData() instanceof Powerable && !event.getBlock().isEmpty()) return;
+
+        event.setCancelled(isInteractionRestricted(event.getSourceBlock(), event.getBlock(),
+                event.getChangedType().hasGravity() ? plugin.flags.gravity : plugin.flags.physics));
+    }
+
+    private boolean isInteractionRestricted(Block source, @Nullable Block target, Flag<Boolean> flag) {
+        var area = plugin.areaProvider().getArea(source);
+        if (!area.getFlag(flag)) return true;
+        return target != null && !source.equals(target) && !area.canInteract(plugin.areaProvider().getArea(target));
+    }
+}

--- a/plugin/src/main/java/net/thenextlvl/protect/listener/WorldListener.java
+++ b/plugin/src/main/java/net/thenextlvl/protect/listener/WorldListener.java
@@ -95,15 +95,6 @@ public class WorldListener implements Listener {
     }
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
-    public void onBlockPhysics(BlockPhysicsEvent event) {
-        event.setCancelled(isInteractionRestricted(
-                event.getSourceBlock().getLocation(),
-                event.getBlock().getLocation(),
-                plugin.flags.physics
-        ));
-    }
-
-    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onBlockFade(BlockFadeEvent event) {
         var area = plugin.areaProvider().getArea(event.getBlock());
         event.setCancelled(!area.getFlag(plugin.flags.blockFading));


### PR DESCRIPTION
Removed the physics event handling from WorldListener and created a dedicated PhysicsListener for managing block physics events. Also added a gravity flag to control physics interactions, and updated event registrations to use the new PhysicsListener.

Vastly improved physics flag to only block actual physics and not arbitrary block updates
Added new `preotct:gravity` flag for more fine-grained control 