### PR TITLE
Add granular permission checks for area commands

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -70,48 +70,48 @@ paper {
         }
     }
     permissions {
+
+        // admin perm-pack
+        register("protect.admin") {
+            description = "Admin permissions for Protect"
+            children = listOf(
+                "protect.bypass.admin",
+                "protect.command.area.create",
+                "protect.command.area.delete",
+                "protect.command.area.info",
+                "protect.command.area.list",
+                "protect.command.area.priority",
+                "protect.commands.area.flag",
+                "protect.commands.area.group",
+                "protect.commands.area.members",
+                "protect.commands.area.owner",
+                "protect.commands.area.parent",
+                "protect.commands.area.schematic"
+            )
+        }
+
         // restriction bypass perm-pack
         register("protect.bypass.admin") {
             description = "Allows players to bypass any restriction"
             children = listOf(
-                "protect.bypass.build",
+                "protect.bypass.attack",
                 "protect.bypass.break",
-                "protect.bypass.interact",
+                "protect.bypass.build",
+                "protect.bypass.empty-bottle",
+                "protect.bypass.empty-bucket",
+                "protect.bypass.enter",
                 "protect.bypass.entity-interact",
+                "protect.bypass.entity-place",
+                "protect.bypass.entity-shear",
+                "protect.bypass.fill-bottle",
+                "protect.bypass.fill-bucket",
+                "protect.bypass.interact",
+                "protect.bypass.leave",
                 "protect.bypass.physical-interact",
                 "protect.bypass.trample",
-                "protect.bypass.enter",
-                "protect.bypass.leave",
-                "protect.bypass.empty-bucket",
-                "protect.bypass.fill-bucket",
-                "protect.bypass.empty-bottle",
-                "protect.bypass.fill-bottle",
+                "protect.bypass.wash-armor",
                 "protect.bypass.wash-banner",
-                "protect.bypass.wash-shulker",
-                "protect.bypass.wash-armor"
-            )
-        }
-
-        // area management perm-pack
-        register("protect.commands.area.manage") {
-            description = "Allows players to manage existing areas"
-            children = listOf(
-                "protect.command.area",
-                "protect.command.area.flag",
-                "protect.command.area.priority",
-                "protect.command.area.redefine",
-                // "protect.command.area.rename",
-                "protect.command.area.schematic"
-            )
-        }
-
-        // non-destructive area perm-pack
-        register("protect.commands.area") {
-            description = "Allows players to interact with areas in a non-destructive manner"
-            children = listOf(
-                "protect.command.area.flag.info",
-                "protect.command.area.info",
-                "protect.command.area.list"
+                "protect.bypass.wash-shulker"
             )
         }
 
@@ -120,9 +120,51 @@ paper {
             description = "Allows players to manage area flags"
             children = listOf(
                 "protect.command.area.flag.info",
-                "protect.command.area.flag.set",
+                "protect.command.area.flag.list",
                 "protect.command.area.flag.reset",
+                "protect.command.area.flag.set",
                 "protect.command.area.protect"
+            )
+        }
+
+        // groups perm-pack
+        register("protect.commands.area.group") {
+            description = "Allows players to manage area groups"
+            children = listOf(
+                "protect.command.area.group.add",
+                "protect.command.area.group.create",
+                "protect.command.area.group.delete",
+                "protect.command.area.group.list",
+                "protect.command.area.group.redefine",
+                "protect.command.area.group.remove"
+            )
+        }
+
+        // members perm-pack
+        register("protect.commands.area.members") {
+            description = "Allows players to manage area members"
+            children = listOf(
+                "protect.command.area.members.add",
+                "protect.command.area.members.list",
+                "protect.command.area.members.remove"
+            )
+        }
+
+        // owner perm-pack
+        register("protect.commands.area.owner") {
+            description = "Allows players to manage area owners"
+            children = listOf(
+                "protect.command.area.owner.remove",
+                "protect.command.area.owner.set"
+            )
+        }
+
+        // parent perm-pack
+        register("protect.commands.area.parent") {
+            description = "Allows players to manage area parents"
+            children = listOf(
+                "protect.command.area.parent.remove",
+                "protect.command.area.parent.set"
             )
         }
 
@@ -135,7 +177,47 @@ paper {
                 "protect.command.area.schematic.save"
             )
         }
-        register("protect.command.area")
+
+        register("protect.command.area.create") { children = listOf("protect.command.area") }
+        register("protect.command.area.delete") { children = listOf("protect.command.area") }
+        register("protect.command.area.flag") { children = listOf("protect.command.area") }
+        register("protect.command.area.group") { children = listOf("protect.command.area") }
+        register("protect.command.area.info") { children = listOf("protect.command.area") }
+        register("protect.command.area.list") { children = listOf("protect.command.area") }
+        register("protect.command.area.members") { children = listOf("protect.command.area") }
+        register("protect.command.area.owner") { children = listOf("protect.command.area") }
+        register("protect.command.area.parent") { children = listOf("protect.command.area") }
+        register("protect.command.area.priority") { children = listOf("protect.command.area") }
+        register("protect.command.area.protect") { children = listOf("protect.command.area") }
+        register("protect.command.area.redefine") { children = listOf("protect.command.area") }
+        register("protect.command.area.schematic") { children = listOf("protect.command.area") }
+        register("protect.command.area.teleport") { children = listOf("protect.command.area") }
+
+        register("protect.command.area.flag.info") { children = listOf("protect.commands.area.flag") }
+        register("protect.command.area.flag.list") { children = listOf("protect.commands.area.flag") }
+        register("protect.command.area.flag.reset") { children = listOf("protect.commands.area.flag") }
+        register("protect.command.area.flag.set") { children = listOf("protect.commands.area.flag") }
+
+        register("protect.command.area.group.add") { children = listOf("protect.commands.area.group") }
+        register("protect.command.area.group.create") { children = listOf("protect.commands.area.group") }
+        register("protect.command.area.group.delete") { children = listOf("protect.commands.area.group") }
+        register("protect.command.area.group.list") { children = listOf("protect.commands.area.group") }
+        register("protect.command.area.group.redefine") { children = listOf("protect.commands.area.group") }
+        register("protect.command.area.group.remove") { children = listOf("protect.commands.area.group") }
+
+        register("protect.command.area.members.add") { children = listOf("protect.commands.area.members") }
+        register("protect.command.area.members.list") { children = listOf("protect.commands.area.members") }
+        register("protect.command.area.members.remove") { children = listOf("protect.commands.area.members") }
+
+        register("protect.command.area.owner.remove") { children = listOf("protect.commands.area.owner") }
+        register("protect.command.area.owner.set") { children = listOf("protect.commands.area.owner") }
+
+        register("protect.command.area.parent.remove") { children = listOf("protect.commands.area.parent") }
+        register("protect.command.area.parent.set") { children = listOf("protect.commands.area.parent") }
+
+        register("protect.command.area.schematic.delete") { children = listOf("protect.command.area.schematic") }
+        register("protect.command.area.schematic.load") { children = listOf("protect.command.area.schematic") }
+        register("protect.command.area.schematic.save") { children = listOf("protect.command.area.schematic") }
     }
 }
 

--- a/plugin/src/main/java/net/thenextlvl/protect/command/AreaMembersCommand.java
+++ b/plugin/src/main/java/net/thenextlvl/protect/command/AreaMembersCommand.java
@@ -30,10 +30,12 @@ class AreaMembersCommand {
         return Commands.literal("members")
                 .requires(stack -> stack.getSender().hasPermission("protect.command.area.members"))
                 .then(Commands.literal("add")
+                        .requires(stack -> stack.getSender().hasPermission("protect.command.area.members.add"))
                         .then(Commands.argument("area", new AreaArgumentType(plugin))
                                 .then(Commands.argument("players", ArgumentTypes.players())
                                         .executes(this::add))))
                 .then(Commands.literal("list")
+                        .requires(stack -> stack.getSender().hasPermission("protect.command.area.members.list"))
                         .then(Commands.argument("area", new AreaArgumentType(plugin))
                                 .executes(context -> {
                                     var area = context.getArgument("area", Area.class);
@@ -44,6 +46,7 @@ class AreaMembersCommand {
                             return list(context, area);
                         }))
                 .then(Commands.literal("remove")
+                        .requires(stack -> stack.getSender().hasPermission("protect.command.area.members.remove"))
                         .then(Commands.argument("area", new AreaArgumentType(plugin, (commandContext, area) ->
                                         !area.getMembers().isEmpty()))
                                 .then(Commands.argument("player", StringArgumentType.word())

--- a/plugin/src/main/java/net/thenextlvl/protect/command/AreaOwnerCommand.java
+++ b/plugin/src/main/java/net/thenextlvl/protect/command/AreaOwnerCommand.java
@@ -23,10 +23,12 @@ class AreaOwnerCommand {
         return Commands.literal("owner")
                 .requires(stack -> stack.getSender().hasPermission("protect.command.area.owner"))
                 .then(Commands.literal("set")
+                        .requires(stack -> stack.getSender().hasPermission("protect.command.area.owner.set"))
                         .then(Commands.argument("area", new AreaArgumentType(plugin))
                                 .then(Commands.argument("player", ArgumentTypes.player())
                                         .executes(this::set))))
                 .then(Commands.literal("remove")
+                        .requires(stack -> stack.getSender().hasPermission("protect.command.area.owner.remove"))
                         .then(Commands.argument("area", new AreaArgumentType(plugin,
                                         (commandContext, area) -> area.getOwner().isPresent()))
                                 .executes(this::remove)));

--- a/plugin/src/main/java/net/thenextlvl/protect/command/AreaParentCommand.java
+++ b/plugin/src/main/java/net/thenextlvl/protect/command/AreaParentCommand.java
@@ -23,10 +23,12 @@ class AreaParentCommand {
         return Commands.literal("parent")
                 .requires(stack -> stack.getSender().hasPermission("protect.command.area.parent"))
                 .then(Commands.literal("set")
+                        .requires(stack -> stack.getSender().hasPermission("protect.command.area.parent.set"))
                         .then(Commands.argument("area", new RegionizedAreaArgumentType(plugin))
                                 .then(Commands.argument("parent", new AreaArgumentType(plugin))
                                         .executes(this::set))))
                 .then(Commands.literal("remove")
+                        .requires(stack -> stack.getSender().hasPermission("protect.command.area.parent.remove"))
                         .then(Commands.argument("area", new AreaArgumentType(plugin,
                                         (commandContext, area) -> area.getParent().isPresent()))
                                 .executes(this::remove)));


### PR DESCRIPTION
Introduced specific permission checks for individual subcommands in the area administration system, improving fine-grained access control. This enhancement ensures that each action, such as adding or removing members, modifying parents, or changing owners, is properly authorized.