### PR TITLE
Update WorldListener to fix source-target filtering

### DIFF
--- a/plugin/src/main/java/net/thenextlvl/protect/listener/WorldListener.java
+++ b/plugin/src/main/java/net/thenextlvl/protect/listener/WorldListener.java
@@ -268,7 +268,7 @@ public class WorldListener implements Listener {
     private <T> void filter(Location source, List<T> list, Function<T, Location> function, @Nullable Player player, Flag<Boolean> flag) {
         filter(source, list, function, (area, target) -> {
             if (player == null) return area.canInteract(target) && target.getFlag(flag);
-            return plugin.protectionService().canPlace(player, target) && target.getFlag(flag);
+            return target.isPermitted(player.getUniqueId()) && target.getFlag(flag);
         });
     }
 


### PR DESCRIPTION
Previously, the filter allowed action only if the player could place. Now, it permits the action if the player is generally allowed. This ensures more accurate permission checks.