### PR TITLE
Fix error when an entity un-targets another entity

### DIFF
--- a/plugin/src/main/java/net/thenextlvl/protect/listener/EntityListener.java
+++ b/plugin/src/main/java/net/thenextlvl/protect/listener/EntityListener.java
@@ -44,6 +44,7 @@ public class EntityListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onEntityTarget(EntityTargetEvent event) {
+        if (event.getTarget() == null) return;
         var area = plugin.areaProvider().getArea(event.getEntity());
         var flag = event.getTarget() instanceof Player
                 ? plugin.flags.entityAttackPlayer


### PR DESCRIPTION
Add a check to return early if the target is null in the onEntityTarget method, ensuring the application does not throw a NullPointerException during such events. This fix addresses a potential bug when an entity untargets another entity in the game.