### PR TITLE
Refactor region mask initialization for clarity

### DIFF
--- a/plugin/src/main/java/net/thenextlvl/protect/mask/ProtectMaskManager.java
+++ b/plugin/src/main/java/net/thenextlvl/protect/mask/ProtectMaskManager.java
@@ -8,6 +8,7 @@ import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.CuboidRegion;
 import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.regions.RegionIntersection;
+import com.sk89q.worldedit.world.World;
 import net.thenextlvl.protect.ProtectPlugin;
 import net.thenextlvl.protect.area.Area;
 import net.thenextlvl.protect.area.GlobalArea;
@@ -16,6 +17,7 @@ import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -54,12 +56,28 @@ public class ProtectMaskManager extends BukkitMaskManager {
             else if (area instanceof GlobalArea) regions.add(GLOBAL);
         }
 
-        return new FaweMask(new RegionIntersection(player.getWorld(), regions)) {
-            @Override
-            public boolean isValid(Player player, MaskType type) {
-                return areas.stream().allMatch(area -> plugin.protectionService().canEdit(bukkit, area));
-            }
-        };
+        return new RegionMask(bukkit, regions, areas, player.getWorld());
+    }
+
+    private final class RegionMask extends FaweMask {
+        private final org.bukkit.entity.Player player;
+        private final Collection<Area> areas;
+
+        public RegionMask(
+                org.bukkit.entity.Player player,
+                Collection<Region> regions,
+                Collection<Area> areas,
+                World world
+        ) {
+            super(new RegionIntersection(world, regions));
+            this.player = player;
+            this.areas = areas;
+        }
+
+        @Override
+        public boolean isValid(Player ignored, MaskType type) {
+            return areas.stream().allMatch(area -> plugin.protectionService().canEdit(player, area));
+        }
     }
 
     public List<Area> getAreas(org.bukkit.entity.Player player, boolean whitelist) {


### PR DESCRIPTION
Replace inline FaweMask instantiation with a dedicated RegionMask class to improve code organization and readability. This change encapsulates the mask's behavior and dependencies, making future enhancements and maintenance more straightforward. The new class structure separates concerns, aligning the implementation with best practices.