### PR TITLE
Fix permission check logic in multi-block filtering

### DIFF
--- a/plugin/src/main/java/net/thenextlvl/protect/listener/WorldListener.java
+++ b/plugin/src/main/java/net/thenextlvl/protect/listener/WorldListener.java
@@ -268,7 +268,7 @@ public class WorldListener implements Listener {
     private <T> void filter(Location source, List<T> list, Function<T, Location> function, @Nullable Player player, Flag<Boolean> flag) {
         filter(source, list, function, (area, target) -> {
             if (player == null) return area.canInteract(target) && target.getFlag(flag);
-            return target.isPermitted(player.getUniqueId()) && target.getFlag(flag);
+            return target.isPermitted(player.getUniqueId()) || target.getFlag(flag);
         });
     }
 


### PR DESCRIPTION
Closes #103 

Previously, the filter logic used an AND condition, which caused issues with permission lookups. This update replaces it with an OR condition to correctly handle cases where either permission or a specific flag grants access.