### PR TITLE
Refactor workflows for consistency and Gradle setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,34 +1,19 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
-# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
-
-name: Java CI with Gradle
-
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
-
+name: Build
+on: [ pull_request, push ]
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Set up JDK 21
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
           distribution: 'temurin'
+          java-version: 21
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Build with Gradle
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: shadowJar
-      - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          path: plugin/build/libs/*
-          if-no-files-found: error
+        run: ./gradlew build
+      - name: Test with Gradle
+        run: ./gradlew test

--- a/.github/workflows/hangar-publish.yml
+++ b/.github/workflows/hangar-publish.yml
@@ -1,24 +1,21 @@
 name: Hangar Publish
-
 on:
   release:
-    types:
-      - prereleased
-      - released
-
+    types: [ prereleased, released ]
 jobs:
   build:
     env:
       HANGAR_API_TOKEN: ${{ secrets.HANGAR_API_TOKEN }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Set up JDK 21
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
           distribution: 'temurin'
+          java-version: 21
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Publish with Gradle to Hangar
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: publishAllPublicationsToHangar
+        run: ./gradlew publishAllPublicationsToHangar

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,11 +1,7 @@
 name: Maven Publish
-
 on:
   release:
-    types:
-      - prereleased
-      - released
-
+    types: [ prereleased, released ]
 jobs:
   build:
     env:
@@ -13,13 +9,14 @@ jobs:
       REPOSITORY_TOKEN: ${{ secrets.REPOSITORY_TOKEN }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Set up JDK 21
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
           distribution: 'temurin'
+          java-version: 21
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Publish with Gradle to Repository
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: publish
+        run: ./gradlew publish

--- a/.github/workflows/modrinth-publish.yml
+++ b/.github/workflows/modrinth-publish.yml
@@ -1,24 +1,21 @@
 name: Modrinth Publish
-
 on:
   release:
-    types:
-      - prereleased
-      - released
-
+    types: [ prereleased, released ]
 jobs:
   build:
     env:
       MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Set up JDK 21
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
           distribution: 'temurin'
+          java-version: 21
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Publish with Gradle to Modrinth
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: modrinth
+        run: ./gradlew modrinth


### PR DESCRIPTION
Aligned workflow files to use consistent naming, updated steps for clarity, and replaced deprecated `setup-gradle@v3` with `setup-gradle@v4`. Simplified `release` types syntax and improved Gradle command usage.