### PR TITLE
Removed `lombok` usage and updated event classes accordingly

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -24,7 +24,6 @@ repositories {
 }
 
 dependencies {
-    compileOnly("org.projectlombok:lombok:1.18.36")
     compileOnly("com.fastasyncworldedit:FastAsyncWorldEdit-Core")
     compileOnly("com.fastasyncworldedit:FastAsyncWorldEdit-Bukkit") { isTransitive = false }
     compileOnly("io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT")
@@ -32,8 +31,6 @@ dependencies {
     implementation("net.thenextlvl.core:nbt:2.3.1")
     implementation("net.thenextlvl.core:files:2.0.2")
     implementation(platform("com.intellectualsites.bom:bom-newest:1.52"))
-
-    annotationProcessor("org.projectlombok:lombok:1.18.36")
 }
 
 publishing {

--- a/api/src/main/java/net/thenextlvl/protect/area/event/AreaDeleteEvent.java
+++ b/api/src/main/java/net/thenextlvl/protect/area/event/AreaDeleteEvent.java
@@ -1,7 +1,5 @@
 package net.thenextlvl.protect.area.event;
 
-import lombok.Getter;
-import lombok.Setter;
 import net.thenextlvl.protect.area.AreaService;
 import net.thenextlvl.protect.area.RegionizedArea;
 import org.bukkit.event.Cancellable;
@@ -13,8 +11,6 @@ import org.jspecify.annotations.NullMarked;
  * <p>
  * Note: Calling {@link AreaService#delete(RegionizedArea)} within this event can lead to an infinite loop.
  */
-@Getter
-@Setter
 @NullMarked
 public class AreaDeleteEvent extends AreaEvent<RegionizedArea<?>> implements Cancellable {
     private boolean cancelled;
@@ -26,5 +22,15 @@ public class AreaDeleteEvent extends AreaEvent<RegionizedArea<?>> implements Can
      */
     public AreaDeleteEvent(RegionizedArea<?> area) {
         super(area);
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
     }
 }

--- a/api/src/main/java/net/thenextlvl/protect/area/event/AreaEvent.java
+++ b/api/src/main/java/net/thenextlvl/protect/area/event/AreaEvent.java
@@ -1,6 +1,5 @@
 package net.thenextlvl.protect.area.event;
 
-import lombok.Getter;
 import net.thenextlvl.protect.area.Area;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
@@ -11,10 +10,9 @@ import org.jspecify.annotations.NullMarked;
  *
  * @param <T> The area type of this event
  */
-@Getter
 @NullMarked
 public abstract class AreaEvent<T extends Area> extends Event {
-    private static final @Getter HandlerList handlerList = new HandlerList();
+    private static final HandlerList handlerList = new HandlerList();
     private final T area;
 
     protected AreaEvent(T area) {
@@ -26,8 +24,16 @@ public abstract class AreaEvent<T extends Area> extends Event {
         this.area = area;
     }
 
+    public T getArea() {
+        return area;
+    }
+
     @Override
     public HandlerList getHandlers() {
-        return getHandlerList();
+        return handlerList;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlerList;
     }
 }

--- a/api/src/main/java/net/thenextlvl/protect/area/event/flag/AreaFlagChangeEvent.java
+++ b/api/src/main/java/net/thenextlvl/protect/area/event/flag/AreaFlagChangeEvent.java
@@ -1,7 +1,5 @@
 package net.thenextlvl.protect.area.event.flag;
 
-import lombok.Getter;
-import lombok.Setter;
 import net.thenextlvl.protect.area.Area;
 import net.thenextlvl.protect.flag.Flag;
 import org.jspecify.annotations.NonNull;
@@ -12,8 +10,6 @@ import org.jspecify.annotations.NonNull;
  *
  * @param <T> The type of the flag value.
  */
-@Getter
-@Setter
 public class AreaFlagChangeEvent<T> extends AreaFlagEvent<T> {
     private T newState;
 
@@ -26,6 +22,14 @@ public class AreaFlagChangeEvent<T> extends AreaFlagEvent<T> {
      */
     public AreaFlagChangeEvent(@NonNull Area area, @NonNull Flag<T> flag, T newState) {
         super(area, flag);
+        this.newState = newState;
+    }
+
+    public T getNewState() {
+        return newState;
+    }
+
+    public void setNewState(T newState) {
         this.newState = newState;
     }
 }

--- a/api/src/main/java/net/thenextlvl/protect/area/event/flag/AreaFlagEvent.java
+++ b/api/src/main/java/net/thenextlvl/protect/area/event/flag/AreaFlagEvent.java
@@ -1,7 +1,5 @@
 package net.thenextlvl.protect.area.event.flag;
 
-import lombok.Getter;
-import lombok.Setter;
 import net.thenextlvl.protect.area.Area;
 import net.thenextlvl.protect.area.event.AreaEvent;
 import net.thenextlvl.protect.flag.Flag;
@@ -13,8 +11,6 @@ import org.jspecify.annotations.NullMarked;
  *
  * @param <T> The type of the flag value.
  */
-@Getter
-@Setter
 @NullMarked
 public abstract class AreaFlagEvent<T> extends AreaEvent<Area> implements Cancellable {
     private final Flag<T> flag;
@@ -29,5 +25,19 @@ public abstract class AreaFlagEvent<T> extends AreaEvent<Area> implements Cancel
     protected AreaFlagEvent(Area area, Flag<T> flag) {
         super(area);
         this.flag = flag;
+    }
+
+    public Flag<T> getFlag() {
+        return flag;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
     }
 }

--- a/api/src/main/java/net/thenextlvl/protect/area/event/flag/AreaProtectEvent.java
+++ b/api/src/main/java/net/thenextlvl/protect/area/event/flag/AreaProtectEvent.java
@@ -1,7 +1,5 @@
 package net.thenextlvl.protect.area.event.flag;
 
-import lombok.Getter;
-import lombok.Setter;
 import net.thenextlvl.protect.area.Area;
 import net.thenextlvl.protect.area.event.AreaEvent;
 import org.bukkit.event.Cancellable;
@@ -13,8 +11,6 @@ import org.jspecify.annotations.NullMarked;
  * that a specific area is to be protected. Users can listen to this event
  * to perform actions related to area protection.
  */
-@Getter
-@Setter
 @NullMarked
 public class AreaProtectEvent extends AreaEvent<Area> implements Cancellable {
     private boolean cancelled;
@@ -26,5 +22,15 @@ public class AreaProtectEvent extends AreaEvent<Area> implements Cancellable {
      */
     public AreaProtectEvent(Area area) {
         super(area);
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
     }
 }

--- a/api/src/main/java/net/thenextlvl/protect/area/event/inheritance/AreaParentChangeEvent.java
+++ b/api/src/main/java/net/thenextlvl/protect/area/event/inheritance/AreaParentChangeEvent.java
@@ -1,7 +1,5 @@
 package net.thenextlvl.protect.area.event.inheritance;
 
-import lombok.Getter;
-import lombok.Setter;
 import net.thenextlvl.protect.area.Area;
 import net.thenextlvl.protect.area.RegionizedArea;
 import net.thenextlvl.protect.area.event.AreaEvent;
@@ -15,8 +13,6 @@ import org.jspecify.annotations.Nullable;
  * <p>
  * Note: Calling {@link RegionizedArea#setParent(Area)} within this event can lead to an infinite loop.
  */
-@Getter
-@Setter
 @NullMarked
 public class AreaParentChangeEvent extends AreaEvent<Area> implements Cancellable {
     private boolean cancelled;
@@ -32,5 +28,23 @@ public class AreaParentChangeEvent extends AreaEvent<Area> implements Cancellabl
     public AreaParentChangeEvent(Area area, @Nullable Area parent) {
         super(area);
         this.parent = parent;
+    }
+
+    public @Nullable Area getParent() {
+        return parent;
+    }
+
+    public void setParent(@Nullable Area parent) {
+        this.parent = parent;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
     }
 }

--- a/api/src/main/java/net/thenextlvl/protect/area/event/inheritance/AreaPriorityChangeEvent.java
+++ b/api/src/main/java/net/thenextlvl/protect/area/event/inheritance/AreaPriorityChangeEvent.java
@@ -1,7 +1,5 @@
 package net.thenextlvl.protect.area.event.inheritance;
 
-import lombok.Getter;
-import lombok.Setter;
 import net.thenextlvl.protect.area.Area;
 import net.thenextlvl.protect.area.event.AreaEvent;
 import org.bukkit.event.Cancellable;
@@ -13,8 +11,6 @@ import org.jspecify.annotations.NullMarked;
  * <p>
  * Note: Calling {@link Area#setPriority(int)} within this event can lead to an infinite loop.
  */
-@Getter
-@Setter
 @NullMarked
 public class AreaPriorityChangeEvent extends AreaEvent<Area> implements Cancellable {
     private boolean cancelled;
@@ -29,5 +25,23 @@ public class AreaPriorityChangeEvent extends AreaEvent<Area> implements Cancella
     public AreaPriorityChangeEvent(Area area, int priority) {
         super(area);
         this.priority = priority;
+    }
+
+    public int getPriority() {
+        return priority;
+    }
+
+    public void setPriority(int priority) {
+        this.priority = priority;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
     }
 }

--- a/api/src/main/java/net/thenextlvl/protect/area/event/member/AreaMemberAddEvent.java
+++ b/api/src/main/java/net/thenextlvl/protect/area/event/member/AreaMemberAddEvent.java
@@ -1,7 +1,5 @@
 package net.thenextlvl.protect.area.event.member;
 
-import lombok.Getter;
-import lombok.Setter;
 import net.thenextlvl.protect.area.Area;
 import net.thenextlvl.protect.area.RegionizedArea;
 import net.thenextlvl.protect.area.event.AreaEvent;
@@ -16,8 +14,6 @@ import java.util.UUID;
  * <p>
  * Note: Calling {@link RegionizedArea#addMember(UUID)} within this event can lead to an infinite loop.
  */
-@Getter
-@Setter
 @NullMarked
 public class AreaMemberAddEvent extends AreaEvent<Area> implements Cancellable {
     private UUID member;
@@ -32,5 +28,23 @@ public class AreaMemberAddEvent extends AreaEvent<Area> implements Cancellable {
     public AreaMemberAddEvent(Area area, UUID member) {
         super(area);
         this.member = member;
+    }
+
+    public UUID getMember() {
+        return member;
+    }
+
+    public void setMember(UUID member) {
+        this.member = member;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
     }
 }

--- a/api/src/main/java/net/thenextlvl/protect/area/event/member/AreaMemberRemoveEvent.java
+++ b/api/src/main/java/net/thenextlvl/protect/area/event/member/AreaMemberRemoveEvent.java
@@ -1,7 +1,5 @@
 package net.thenextlvl.protect.area.event.member;
 
-import lombok.Getter;
-import lombok.Setter;
 import net.thenextlvl.protect.area.Area;
 import net.thenextlvl.protect.area.RegionizedArea;
 import net.thenextlvl.protect.area.event.AreaEvent;
@@ -17,8 +15,6 @@ import java.util.UUID;
  * <p>
  * Note: Calling {@link RegionizedArea#removeMember(UUID)} within this event can lead to an infinite loop.
  */
-@Getter
-@Setter
 @NullMarked
 public class AreaMemberRemoveEvent extends AreaEvent<Area> implements Cancellable {
     private UUID member;
@@ -33,5 +29,23 @@ public class AreaMemberRemoveEvent extends AreaEvent<Area> implements Cancellabl
     public AreaMemberRemoveEvent(Area area, UUID member) {
         super(area);
         this.member = member;
+    }
+
+    public UUID getMember() {
+        return member;
+    }
+
+    public void setMember(UUID member) {
+        this.member = member;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
     }
 }

--- a/api/src/main/java/net/thenextlvl/protect/area/event/member/AreaOwnerChangeEvent.java
+++ b/api/src/main/java/net/thenextlvl/protect/area/event/member/AreaOwnerChangeEvent.java
@@ -1,7 +1,5 @@
 package net.thenextlvl.protect.area.event.member;
 
-import lombok.Getter;
-import lombok.Setter;
 import net.thenextlvl.protect.area.Area;
 import net.thenextlvl.protect.area.RegionizedArea;
 import net.thenextlvl.protect.area.event.AreaEvent;
@@ -17,8 +15,6 @@ import java.util.UUID;
  * <p>
  * Note: Calling {@link RegionizedArea#setOwner(UUID)} within this event can lead to an infinite loop.
  */
-@Getter
-@Setter
 @NullMarked
 public class AreaOwnerChangeEvent extends AreaEvent<Area> implements Cancellable {
     private @Nullable UUID owner;
@@ -33,5 +29,23 @@ public class AreaOwnerChangeEvent extends AreaEvent<Area> implements Cancellable
     public AreaOwnerChangeEvent(Area area, @Nullable UUID owner) {
         super(area);
         this.owner = owner;
+    }
+
+    public @Nullable UUID getOwner() {
+        return owner;
+    }
+
+    public void setOwner(@Nullable UUID owner) {
+        this.owner = owner;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
     }
 }

--- a/api/src/main/java/net/thenextlvl/protect/area/event/player/PlayerAreaEnterEvent.java
+++ b/api/src/main/java/net/thenextlvl/protect/area/event/player/PlayerAreaEnterEvent.java
@@ -1,7 +1,5 @@
 package net.thenextlvl.protect.area.event.player;
 
-import lombok.Getter;
-import lombok.Setter;
 import net.thenextlvl.protect.area.Area;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
@@ -13,8 +11,6 @@ import org.jspecify.annotations.NullMarked;
  * Players entering an area can be intercepted by listening for this event.
  * If the event is cancelled, the player is prevented from entering the area.
  */
-@Getter
-@Setter
 @NullMarked
 public class PlayerAreaEnterEvent extends PlayerAreaEvent implements Cancellable {
     private boolean cancelled;
@@ -27,5 +23,15 @@ public class PlayerAreaEnterEvent extends PlayerAreaEvent implements Cancellable
      */
     public PlayerAreaEnterEvent(Player player, Area area) {
         super(player, area);
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
     }
 }

--- a/api/src/main/java/net/thenextlvl/protect/area/event/player/PlayerAreaEvent.java
+++ b/api/src/main/java/net/thenextlvl/protect/area/event/player/PlayerAreaEvent.java
@@ -1,6 +1,5 @@
 package net.thenextlvl.protect.area.event.player;
 
-import lombok.Getter;
 import net.thenextlvl.protect.area.Area;
 import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
@@ -10,10 +9,9 @@ import org.jspecify.annotations.NullMarked;
 /**
  * This class represents an abstract base class for events related to areas and players.
  */
-@Getter
 @NullMarked
 public abstract class PlayerAreaEvent extends PlayerEvent {
-    private static final @Getter HandlerList handlerList = new HandlerList();
+    private static final HandlerList handlerList = new HandlerList();
     private final Area area;
 
     /**
@@ -27,8 +25,16 @@ public abstract class PlayerAreaEvent extends PlayerEvent {
         this.area = area;
     }
 
+    public Area getArea() {
+        return area;
+    }
+
     @Override
     public HandlerList getHandlers() {
-        return getHandlerList();
+        return handlerList;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlerList;
     }
 }

--- a/api/src/main/java/net/thenextlvl/protect/area/event/player/PlayerAreaLeaveEvent.java
+++ b/api/src/main/java/net/thenextlvl/protect/area/event/player/PlayerAreaLeaveEvent.java
@@ -1,7 +1,5 @@
 package net.thenextlvl.protect.area.event.player;
 
-import lombok.Getter;
-import lombok.Setter;
 import net.thenextlvl.protect.area.Area;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
@@ -14,8 +12,6 @@ import org.jspecify.annotations.NullMarked;
  * Players leaving an area can be intercepted by listening for this event.
  * If the event is cancelled, the player is prevented from leaving the area.
  */
-@Getter
-@Setter
 @NullMarked
 public class PlayerAreaLeaveEvent extends PlayerAreaEvent implements Cancellable {
     private boolean cancelled;
@@ -28,5 +24,15 @@ public class PlayerAreaLeaveEvent extends PlayerAreaEvent implements Cancellable
      */
     public PlayerAreaLeaveEvent(Player player, Area area) {
         super(player, area);
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
     }
 }

--- a/api/src/main/java/net/thenextlvl/protect/area/event/player/PlayerAreaTransitionEvent.java
+++ b/api/src/main/java/net/thenextlvl/protect/area/event/player/PlayerAreaTransitionEvent.java
@@ -1,7 +1,5 @@
 package net.thenextlvl.protect.area.event.player;
 
-import lombok.Getter;
-import lombok.Setter;
 import net.thenextlvl.protect.area.Area;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
@@ -11,8 +9,6 @@ import org.jspecify.annotations.NullMarked;
  * This event is triggered whenever a player transitions to a new area.
  * Cancelling this event results in the player not being able to move to the new area.
  */
-@Getter
-@Setter
 @NullMarked
 public class PlayerAreaTransitionEvent extends PlayerAreaEvent implements Cancellable {
     private final Area previous;
@@ -28,5 +24,19 @@ public class PlayerAreaTransitionEvent extends PlayerAreaEvent implements Cancel
     public PlayerAreaTransitionEvent(Player player, Area from, Area to) {
         super(player, to);
         this.previous = from;
+    }
+
+    public Area getPrevious() {
+        return previous;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
     }
 }

--- a/api/src/main/java/net/thenextlvl/protect/area/event/region/AreaRedefineEvent.java
+++ b/api/src/main/java/net/thenextlvl/protect/area/event/region/AreaRedefineEvent.java
@@ -1,8 +1,6 @@
 package net.thenextlvl.protect.area.event.region;
 
 import com.sk89q.worldedit.regions.Region;
-import lombok.Getter;
-import lombok.Setter;
 import net.thenextlvl.protect.area.RegionizedArea;
 import net.thenextlvl.protect.area.event.AreaEvent;
 import org.bukkit.event.Cancellable;
@@ -14,8 +12,6 @@ import org.jspecify.annotations.NullMarked;
  *
  * @param <T> The type of region associated with the area of this event
  */
-@Getter
-@Setter
 @NullMarked
 public class AreaRedefineEvent<T extends Region> extends AreaEvent<RegionizedArea<T>> implements Cancellable {
     private boolean cancelled;
@@ -30,5 +26,23 @@ public class AreaRedefineEvent<T extends Region> extends AreaEvent<RegionizedAre
     public AreaRedefineEvent(RegionizedArea<T> area, T region) {
         super(area);
         this.region = region;
+    }
+
+    public T getRegion() {
+        return region;
+    }
+
+    public void setRegion(T region) {
+        this.region = region;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
     }
 }

--- a/api/src/main/java/net/thenextlvl/protect/area/event/schematic/AreaSchematicDeleteEvent.java
+++ b/api/src/main/java/net/thenextlvl/protect/area/event/schematic/AreaSchematicDeleteEvent.java
@@ -1,7 +1,5 @@
 package net.thenextlvl.protect.area.event.schematic;
 
-import lombok.Getter;
-import lombok.Setter;
 import net.thenextlvl.protect.area.RegionizedArea;
 import net.thenextlvl.protect.area.event.AreaEvent;
 import org.bukkit.event.Cancellable;
@@ -11,8 +9,6 @@ import org.jspecify.annotations.NullMarked;
  * This event is triggered when a schematic associated with an area is about to be deleted.
  * Cancelling this event results in the schematic not being deleted.
  */
-@Getter
-@Setter
 @NullMarked
 public class AreaSchematicDeleteEvent extends AreaEvent<RegionizedArea<?>> implements Cancellable {
     private boolean cancelled;
@@ -24,5 +20,15 @@ public class AreaSchematicDeleteEvent extends AreaEvent<RegionizedArea<?>> imple
      */
     public AreaSchematicDeleteEvent(RegionizedArea<?> area) {
         super(area);
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
     }
 }

--- a/api/src/main/java/net/thenextlvl/protect/area/event/schematic/AreaSchematicLoadEvent.java
+++ b/api/src/main/java/net/thenextlvl/protect/area/event/schematic/AreaSchematicLoadEvent.java
@@ -1,7 +1,5 @@
 package net.thenextlvl.protect.area.event.schematic;
 
-import lombok.Getter;
-import lombok.Setter;
 import net.thenextlvl.protect.area.RegionizedArea;
 import net.thenextlvl.protect.area.event.AreaEvent;
 import org.bukkit.event.Cancellable;
@@ -11,8 +9,6 @@ import org.jspecify.annotations.NullMarked;
  * This event is fired when a schematic of a regionized area is loaded.
  * This event is cancellable, meaning it can be prevented from proceeding.
  */
-@Getter
-@Setter
 @NullMarked
 public class AreaSchematicLoadEvent extends AreaEvent<RegionizedArea<?>> implements Cancellable {
     private boolean cancelled;
@@ -24,5 +20,15 @@ public class AreaSchematicLoadEvent extends AreaEvent<RegionizedArea<?>> impleme
      */
     public AreaSchematicLoadEvent(RegionizedArea<?> area) {
         super(area);
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
     }
 }

--- a/api/src/main/java/net/thenextlvl/protect/exception/UnsupportedRegionException.java
+++ b/api/src/main/java/net/thenextlvl/protect/exception/UnsupportedRegionException.java
@@ -1,9 +1,7 @@
 package net.thenextlvl.protect.exception;
 
-import lombok.Getter;
 import org.jspecify.annotations.NullMarked;
 
-@Getter
 @NullMarked
 public class UnsupportedRegionException extends IllegalArgumentException {
     private final Class<?> type;
@@ -25,5 +23,9 @@ public class UnsupportedRegionException extends IllegalArgumentException {
     public UnsupportedRegionException(Class<?> type, Throwable cause) {
         super(cause);
         this.type = type;
+    }
+
+    public Class<?> getType() {
+        return type;
     }
 }


### PR DESCRIPTION
Replaced `@Getter` and `@Setter` annotations with explicit methods across all event classes. Removed `lombok` dependency from build script. This streamlines code and reduces external dependencies.