### PR TITLE
Added SCM info to build.gradle.kts

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -36,6 +36,14 @@ dependencies {
 
 publishing {
     publications.create<MavenPublication>("maven") {
+        artifactId = "protect"
+        groupId = "net.thenextlvl"
+        pom.scm {
+            val repository = "TheNextLvl-net/protect"
+            url.set("https://github.com/$repository")
+            connection.set("scm:git:git://github.com/$repository.git")
+            developerConnection.set("scm:git:ssh://github.com/$repository.git")
+        }
         from(components["java"])
     }
     repositories.maven {


### PR DESCRIPTION
Breaking change: The API will be published to `net.thenextlvl:protect` instead of `net.thenextlvl.protect:api` from now on